### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,7 @@ For example, you can import the specification into [SwaggerHub](https://github.c
 
 To get up and running with Akismet, take a look at our Getting Started guide:
 
-https://akismet.com/getting-started
-
+[https://akismet.com/developers/getting-started](https://akismet.com/developers/getting-started)
 You can view full documentation for each endpoint at:
 
-https://akismet.com/developers
+[https://akismet.com/developers](https://akismet.com/developers)


### PR DESCRIPTION
getting-started was moved from `/getting-started` to `/developers/getting-started` this PR updates that link. 

(Aside, we should consider a redirect at the application level, it currently returns a 404)