### PR TITLE
Add /1.1/get-stats and /1.2/get-key-stats endpoints

### DIFF
--- a/spec.yml
+++ b/spec.yml
@@ -405,7 +405,7 @@ paths:
           description: |
             The time period for the returned stats. Three values are accepted: 60-days, 6-months, and all. The default value is 6-months.
 
-            A key must have daily stats enabled to receive stats for 60-days. If key does not have daily stats enabled, the default value of 6-months will be used.
+            A key must have daily stats enabled to receive stats for 60-days. If the key does not have daily stats enabled, the default value of 6-months will be used.
 
             The response includes a breakdown of stats based on the queried time period (6-months: breakdown by month, 60-days: breakdown by day, all: breakdown by year).
           required: false
@@ -475,7 +475,7 @@ paths:
           description: |
             The time period for the returned stats. Three values are accepted: 60-days, 6-months, and all. The default value is 6-months.
 
-            A key must have daily stats enabled to receive stats for 60-days. If key does not have daily stats enabled, the default value of 6-months will be used.
+            A key must have daily stats enabled to receive stats for 60-days. If the key does not have daily stats enabled, the default value of 6-months will be used.
 
             The response includes a breakdown of stats based on the queried time period (6-months: breakdown by month, 60-days: breakdown by day, all: breakdown by year).
           required: false

--- a/spec.yml
+++ b/spec.yml
@@ -402,9 +402,7 @@ paths:
         - name: from
           in: query
           description: |
-            The time period for the returned stats. Three values are accepted: 60-days, 6-months, and all. The default value is 6-months. A key must
-            have daily stats enabled to receive stats for 60-days. If it does not, the default value of 6-months will be used.
-            The response includes a breakdown of stats by time period:
+            The time period for the returned stats. Three values are accepted: 60-days, 6-months, and all. The default value is 6-months. A key must have daily stats enabled to receive stats for 60-days. If it does not, the default value of 6-months will be used. The response includes a breakdown of stats by time period:
               6-months: breakdown by month
               60-days: breakdown by day
               all: breakdown by year
@@ -416,23 +414,41 @@ paths:
               - 6-months
               - all
       responses:
-          '200':
-            description: Key sites response.
-            content:
-              application/json:
-                schema:
-                  type: object
-                  # OpenAPI Generator doesn't work well with a mixture of properties and additionalProperties,
-                  # so have left the response free-form
-                  additionalProperties: true
-                  example:
-
-              text/plain:
-                schema:
-                  type: string
-                examples:
-                  error:
-                    value: "invalid"
+        '200':
+          description: Get key stats response.
+          content:
+            application/json:
+              schema:
+                type: object
+                # OpenAPI Generator doesn't work well with a mixture of properties and additionalProperties,
+                # so have left the response free-form
+                additionalProperties: true
+                example:
+                  'spam': 50
+                  'ham': 137
+                  'missed_spam': 3
+                  'false_positives': 4
+                  'accuracy': 96.25
+                  'breakdown':
+                    '2023-10':
+                      'spam': 30
+                      'ham': 85
+                      'missed_spam': 2
+                      'false_positives': 3
+                      'da': '2023-10-01'
+                    '2023-09':
+                      'spam': 20
+                      'ham': 52
+                      'missed_spam': 1
+                      'false_positives': 1
+                      'da': '2023-09-01'
+                  'time_saved': 3000
+            text/plain:
+              schema:
+                type: string
+              examples:
+                error:
+                  value: "invalid"
       tags:
         - key-usage
   /1.2/get-key-stats:
@@ -440,8 +456,7 @@ paths:
       operationId: getKeyStats
       summary: Returns the stats for an API key.
       description: |
-        Returns the stats for an API key. The stats consist of total values of spam, ham, missed spam reports, false positive reports, accuracy,
-        and stats breakdown for the requested time periods.
+        Returns the stats for an API key. The stats consist of total values of spam, ham, missed spam reports, false positive reports, accuracy, and stats breakdown for the requested time periods.
       parameters:
         - name: api_key
           in: query
@@ -460,9 +475,7 @@ paths:
         - name: from
           in: query
           description: |
-            The time period for the returned stats. Three values are accepted: 60-days, 6-months, and all. The default value is 6-months. A key must
-            have daily stats enabled to receive stats for 60-days. If it doesn't not, the default value of 6-months will be used.
-            The response includes a breakdown of stats by time period:
+            The time period for the returned stats. Three values are accepted: 60-days, 6-months, and all. The default value is 6-months. A key must have daily stats enabled to receive stats for 60-days. If it doesn't not, the default value of 6-months will be used. The response includes a breakdown of stats by time period:
               6-months: breakdown by month
               60-days: breakdown by day
               all: breakdown by year
@@ -484,27 +497,27 @@ paths:
                   # so have left the response free-form
                   additionalProperties: true
                   example:
-                    'spam': 123
-                    'ham': 45
-                    'missed_spam': 2
-                    'false_positives': 1
-                    'accuracy':
+                    'spam': 50
+                    'ham': 137
+                    'missed_spam': 3
+                    'false_positives': 4
+                    'accuracy': 96.25
                     'breakdown':
                       '2023-10':
-                        'spam':
-                        'ham':
-                        'missed_spam':
-                        'false_positives':
-                        'blogs':
+                        'spam': 30
+                        'ham': 85
+                        'missed_spam': 2
+                        'false_positives': 3
+                        'blogs': 1
                         'da': '2023-10-01'
-                       '2023-09':
-                        'spam':
-                        'ham':
-                        'missed_spam':
-                        'false_positives':
-                        'blogs':
+                      '2023-09':
+                        'spam': 20
+                        'ham': 52
+                        'missed_spam': 1
+                        'false_positives': 1
+                        'blogs': 1
                         'da': '2023-09-01'
-                    'time_saved':
+                    'time_saved': 3000
               text/plain:
                 schema:
                   type: string
@@ -519,4 +532,4 @@ tags:
   - name: spam
     description: Check for spam, and submit spam or ham (false positives)
   - name: key-usage
-    description: Check which sites use your API key and how many requests are being made        
+    description: Check which sites use your API key and how many requests are being made

--- a/spec.yml
+++ b/spec.yml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: Akismet API
   description: Developer API to interact with the Akismet spam detection service.
-  version: 1.0.0
+  version: 1.1.0
   contact:
     name: Contact Akismet
     url: https://akismet.com/contact
@@ -381,9 +381,10 @@ paths:
   /1.1/get-stats:
     post:
       operationId: getStats
-      summary: Get the stats for an API key and site.
+      summary: Returns the stats for an API key and site.
       description: |
-        Returns the stats for an API key and site associated with that key.
+        Returns the stats for an API key and site associated with that key. The stats consist of total values of spam, ham, missed spam reports, false positive reports, accuracy, a stats breakdown for the requested time period, and the time saved by using Akismet to catch spam.
+
       parameters:
         - name: api_key
           in: query
@@ -402,10 +403,11 @@ paths:
         - name: from
           in: query
           description: |
-            The time period for the returned stats. Three values are accepted: 60-days, 6-months, and all. The default value is 6-months. A key must have daily stats enabled to receive stats for 60-days. If it does not, the default value of 6-months will be used. The response includes a breakdown of stats by time period:
-              6-months: breakdown by month
-              60-days: breakdown by day
-              all: breakdown by year
+            The time period for the returned stats. Three values are accepted: 60-days, 6-months, and all. The default value is 6-months.
+
+            A key must have daily stats enabled to receive stats for 60-days. If key does not have daily stats enabled, the default value of 6-months will be used.
+
+            The response includes a breakdown of stats based on the queried time period (6-months: breakdown by month, 60-days: breakdown by day, all: breakdown by year).
           required: false
           schema:
             type: string
@@ -415,7 +417,7 @@ paths:
               - all
       responses:
         '200':
-          description: Get key stats response.
+          description: Get stats response.
           content:
             application/json:
               schema:
@@ -449,6 +451,9 @@ paths:
               examples:
                 error:
                   value: "invalid"
+          headers:
+            X-akismet-debug-help:
+              $ref: '#/components/headers/DebugHelpHeader'
       tags:
         - key-usage
   /1.2/get-key-stats:
@@ -456,7 +461,7 @@ paths:
       operationId: getKeyStats
       summary: Returns the stats for an API key.
       description: |
-        Returns the stats for an API key. The stats consist of total values of spam, ham, missed spam reports, false positive reports, accuracy, and stats breakdown for the requested time periods.
+        Returns the stats for an API key. The stats consist of total values of spam, ham, missed spam reports, false positive reports, accuracy, a stats breakdown for the requested time period, and the time saved by using Akismet to catch spam.
       parameters:
         - name: api_key
           in: query
@@ -465,20 +470,14 @@ paths:
           schema:
             type: string
 
-        - name: blog
-          in: query
-          description: The front page or home URL of the instance making the request.
-          required: true
-          schema:
-            type: string
-
         - name: from
           in: query
           description: |
-            The time period for the returned stats. Three values are accepted: 60-days, 6-months, and all. The default value is 6-months. A key must have daily stats enabled to receive stats for 60-days. If it doesn't not, the default value of 6-months will be used. The response includes a breakdown of stats by time period:
-              6-months: breakdown by month
-              60-days: breakdown by day
-              all: breakdown by year
+            The time period for the returned stats. Three values are accepted: 60-days, 6-months, and all. The default value is 6-months.
+
+            A key must have daily stats enabled to receive stats for 60-days. If key does not have daily stats enabled, the default value of 6-months will be used.
+
+            The response includes a breakdown of stats based on the queried time period (6-months: breakdown by month, 60-days: breakdown by day, all: breakdown by year).
           required: false
           schema:
             type: string
@@ -487,43 +486,46 @@ paths:
               - 6-months
               - all
       responses:
-          '200':
-            description: Get key stats response.
-            content:
-              application/json:
-                schema:
-                  type: object
-                  # OpenAPI Generator doesn't work well with a mixture of properties and additionalProperties,
-                  # so have left the response free-form
-                  additionalProperties: true
-                  example:
-                    'spam': 50
-                    'ham': 137
-                    'missed_spam': 3
-                    'false_positives': 4
-                    'accuracy': 96.25
-                    'breakdown':
-                      '2023-10':
-                        'spam': 30
-                        'ham': 85
-                        'missed_spam': 2
-                        'false_positives': 3
-                        'blogs': 1
-                        'da': '2023-10-01'
-                      '2023-09':
-                        'spam': 20
-                        'ham': 52
-                        'missed_spam': 1
-                        'false_positives': 1
-                        'blogs': 1
-                        'da': '2023-09-01'
+        '200':
+          description: Get key stats response.
+          content:
+            application/json:
+              schema:
+                type: object
+                # OpenAPI Generator doesn't work well with a mixture of properties and additionalProperties,
+                # so have left the response free-form
+                additionalProperties: true
+                example:
+                  'spam': 50
+                  'ham': 137
+                  'missed_spam': 3
+                  'false_positives': 4
+                  'accuracy': 96.25
+                  'breakdown':
+                    '2023-10':
+                      'spam': 30
+                      'ham': 85
+                      'missed_spam': 2
+                      'false_positives': 3
+                      'blogs': 1
+                      'da': '2023-10-01'
+                    '2023-09':
+                      'spam': 20
+                      'ham': 52
+                      'missed_spam': 1
+                      'false_positives': 1
+                      'blogs': 1
+                      'da': '2023-09-01'
                     'time_saved': 3000
-              text/plain:
-                schema:
-                  type: string
-                examples:
-                  error:
-                    value: "invalid"
+            text/plain:
+              schema:
+                type: string
+              examples:
+                error:
+                  value: "invalid"
+          headers:
+            X-akismet-debug-help:
+              $ref: '#/components/headers/DebugHelpHeader'
       tags:
         - key-usage
 tags:

--- a/spec.yml
+++ b/spec.yml
@@ -378,6 +378,141 @@ paths:
                     value: "invalid"
       tags:
         - key-usage
+  /1.1/get-stats:
+    post:
+      operationId: getStats
+      summary: Get the stats for an API key and site.
+      description: |
+        Returns the stats for an API key and site associated with that key.
+      parameters:
+        - name: api_key
+          in: query
+          description: The Akismet API key for authorization.
+          required: true
+          schema:
+            type: string
+
+        - name: blog
+          in: query
+          description: The front page or home URL of the instance making the request.
+          required: true
+          schema:
+            type: string
+
+        - name: from
+          in: query
+          description: |
+            The time period for the returned stats. Three values are accepted: 60-days, 6-months, and all. The default value is 6-months. A key must
+            have daily stats enabled to receive stats for 60-days. If it does not, the default value of 6-months will be used.
+            The response includes a breakdown of stats by time period:
+              6-months: breakdown by month
+              60-days: breakdown by day
+              all: breakdown by year
+          required: false
+          schema:
+            type: string
+            enum:
+              - 60-days
+              - 6-months
+              - all
+      responses:
+          '200':
+            description: Key sites response.
+            content:
+              application/json:
+                schema:
+                  type: object
+                  # OpenAPI Generator doesn't work well with a mixture of properties and additionalProperties,
+                  # so have left the response free-form
+                  additionalProperties: true
+                  example:
+
+              text/plain:
+                schema:
+                  type: string
+                examples:
+                  error:
+                    value: "invalid"
+      tags:
+        - key-usage
+  /1.2/get-key-stats:
+    post:
+      operationId: getKeyStats
+      summary: Returns the stats for an API key.
+      description: |
+        Returns the stats for an API key. The stats consist of total values of spam, ham, missed spam reports, false positive reports, accuracy,
+        and stats breakdown for the requested time periods.
+      parameters:
+        - name: api_key
+          in: query
+          description: The Akismet API key for authorization.
+          required: true
+          schema:
+            type: string
+
+        - name: blog
+          in: query
+          description: The front page or home URL of the instance making the request.
+          required: true
+          schema:
+            type: string
+
+        - name: from
+          in: query
+          description: |
+            The time period for the returned stats. Three values are accepted: 60-days, 6-months, and all. The default value is 6-months. A key must
+            have daily stats enabled to receive stats for 60-days. If it doesn't not, the default value of 6-months will be used.
+            The response includes a breakdown of stats by time period:
+              6-months: breakdown by month
+              60-days: breakdown by day
+              all: breakdown by year
+          required: false
+          schema:
+            type: string
+            enum:
+              - 60-days
+              - 6-months
+              - all
+      responses:
+          '200':
+            description: Get key stats response.
+            content:
+              application/json:
+                schema:
+                  type: object
+                  # OpenAPI Generator doesn't work well with a mixture of properties and additionalProperties,
+                  # so have left the response free-form
+                  additionalProperties: true
+                  example:
+                    'spam': 123
+                    'ham': 45
+                    'missed_spam': 2
+                    'false_positives': 1
+                    'accuracy':
+                    'breakdown':
+                      '2023-10':
+                        'spam':
+                        'ham':
+                        'missed_spam':
+                        'false_positives':
+                        'blogs':
+                        'da': '2023-10-01'
+                       '2023-09':
+                        'spam':
+                        'ham':
+                        'missed_spam':
+                        'false_positives':
+                        'blogs':
+                        'da': '2023-09-01'
+                    'time_saved':
+              text/plain:
+                schema:
+                  type: string
+                examples:
+                  error:
+                    value: "invalid"
+      tags:
+        - key-usage
 tags:
   - name: key-verification
     description: Verify Akismet API key

--- a/spec.yml
+++ b/spec.yml
@@ -386,7 +386,7 @@ paths:
         Returns the stats for an API key and site associated with that key. The stats consist of total values of spam, ham, missed spam reports, false positive reports, accuracy, a stats breakdown for the requested time period, and the time saved by using Akismet to catch spam.
 
       parameters:
-        - name: api_key
+        - name: key
           in: query
           description: The Akismet API key for authorization.
           required: true
@@ -463,7 +463,7 @@ paths:
       description: |
         Returns the stats for an API key. The stats consist of total values of spam, ham, missed spam reports, false positive reports, accuracy, a stats breakdown for the requested time period, and the time saved by using Akismet to catch spam.
       parameters:
-        - name: api_key
+        - name: key
           in: query
           description: The Akismet API key for authorization.
           required: true


### PR DESCRIPTION
Add the `/1.1/get-stats` and `/1.2/get-key-stats` endpoints to the OpenAPI specification.

## Test instructions
1. If you have a SwaggerHub account, load the spec.yml file in Swagger hub.
2. Verify that the specifications for the `/1.1/get-stats` and `/1.2/get-key-stats` endpoints are correct.