### PR TITLE
Fix /1.2/key-sites examples to match live backend responses

### DIFF
--- a/spec.yml
+++ b/spec.yml
@@ -321,16 +321,23 @@ paths:
                   additionalProperties: true
                   example:
                     '2023-07':
-                      site: example.com
-                      api_calls: 1000
-                      spam: 434
-                      ham: 544
-                      missed_spam: 5
-                      false_positives: 2
-                      is_revoked: false
+                      - site: example.com
+                        api_calls: 1000
+                        spam: 434
+                        ham: 544
+                        missed_spam: 5
+                        false_positives: 2
+                        is_revoked: false
+                      - site: example.org
+                        api_calls: 250
+                        spam: 150
+                        ham: 100
+                        missed_spam: 0
+                        false_positives: 1
+                        is_revoked: false
                     limit: 500
                     offset: 0
-                    total: 5
+                    total: 2
 
               text/csv:
                 schema:

--- a/spec.yml
+++ b/spec.yml
@@ -343,7 +343,7 @@ paths:
                 schema:
                   type: string
                 example: |
-                  Active sites for 123YourAPIKey during 2022-09 (limit:10, offset: 0, total: 4)
+                  Active sites for 123YourAPIKey during 2022-09 (limit: 10, offset: 0, total: 4).
                   Site,Total API Calls,Spam,Ham,Missed Spam,False Positives,Is Revoked
                   site6735.domain.tld,14446,33,13,0,9,false
                   site3026.domain.tld,8677,101,6,0,0,false

--- a/spec.yml
+++ b/spec.yml
@@ -322,18 +322,18 @@ paths:
                   example:
                     '2023-07':
                       - site: example.com
-                        api_calls: 1000
-                        spam: 434
-                        ham: 544
-                        missed_spam: 5
-                        false_positives: 2
+                        api_calls: "1000"
+                        spam: "434"
+                        ham: "544"
+                        missed_spam: "5"
+                        false_positives: "2"
                         is_revoked: false
                       - site: example.org
-                        api_calls: 250
-                        spam: 150
-                        ham: 100
-                        missed_spam: 0
-                        false_positives: 1
+                        api_calls: "250"
+                        spam: "150"
+                        ham: "100"
+                        missed_spam: "0"
+                        false_positives: "1"
                         is_revoked: false
                     limit: 500
                     offset: 0


### PR DESCRIPTION
The `/1.2/key-sites` examples in the spec didn't match what the backend actually returns. The PHP SDK already parses the real shapes, so consumers generated from the old examples would be wrong.

- The month key now holds an array of site objects (the old example showed a single flat object). Two entries so the list shape is obvious, and `total` matches the site count.
- The per-site stat values (`api_calls`, `spam`, `ham`, `missed_spam`, `false_positives`) are quoted as strings, matching the raw DB values the backend echoes. `is_revoked` stays boolean and the top-level `limit`/`offset`/`total` stay integers.
- The CSV example's header line gains the space after `limit:` and the trailing period the backend has emitted since Jan 2023.

I also audited the other endpoints' examples against the backend (verify-key, comment-check, submit-spam/ham, usage-limit); they all match. Details in the comments below. One backend-side finding from that audit is tracked separately as AKISMET-465 (every response ships as `Content-Type: text/plain`).

Related: AKISMET-133