### PR TITLE
Akismet: add changelog and bump spec version to 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to the Akismet API spec are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.1]
+
+### Fixed
+
+- Corrected the `/1.2/key-sites` examples to match live backend responses: the `month` key now contains an array of site objects, per-site statistics are represented as quoted strings, and the CSV example header was updated to match backend output. ([#3](https://github.com/Automattic/akismet-api/pull/3))
+
+## [1.0.0]
+
+- Initial release of the Akismet API spec.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Corrected the `/1.2/key-sites` examples to match live backend responses: the `month` key now contains an array of site objects, per-site statistics are represented as quoted strings, and the CSV example header was updated to match backend output. ([#3](https://github.com/Automattic/akismet-api/pull/3))
+- Corrected the `/1.2/key-sites` examples to match live backend responses. ([#3](https://github.com/Automattic/akismet-api/pull/3))
 
 ## [1.0.0]
 

--- a/spec.yml
+++ b/spec.yml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: Akismet API
   description: Developer API to interact with the Akismet spam detection service.
-  version: 1.0.0
+  version: 1.0.1
   contact:
     name: Contact Akismet
     url: https://akismet.com/contact


### PR DESCRIPTION
## Summary

- Adds a `CHANGELOG.md` following the Keep a Changelog format.
- Records #3 (fix `/1.2/key-sites` examples to match live backend responses) as the first 1.0.1 changelog entry.
- Bumps the spec version from 1.0.0 to 1.0.1.

## Test plan

- Verified `spec.yml` `info.version` reads `1.0.1`.
- Confirmed `CHANGELOG.md` links to #3 under the 1.0.1 section.